### PR TITLE
[HAN-91] Ver feed

### DIFF
--- a/app/controller/Social.py
+++ b/app/controller/Social.py
@@ -1,6 +1,7 @@
 from typing import Optional
 from app.schemas.Post import (
     PostCreateSchema,
+    PostPagination,
     PostPartialUpdateSchema,
     PostSchema,
 )
@@ -54,4 +55,12 @@ class SocialController:
         return JSONResponse(
             status_code=status.HTTP_200_OK,
             content="Post deleted successfully",
+        )
+
+    async def handle_get_my_feed(
+        self, id_user: str, pagination: PostPagination
+    ) -> JSONResponse:
+        list = await self.social_service.get_my_feed(id_user, pagination)
+        return JSONResponse(
+            status_code=status.HTTP_200_OK, content=jsonable_encoder(list)
         )

--- a/app/controller/Social.py
+++ b/app/controller/Social.py
@@ -70,7 +70,9 @@ class SocialController:
     async def handle_create_social_user(
         self, input_user: SocialUserCreateSchema
     ) -> JSONResponse:
-        user: SocialUserSchema = await self.social_service.create_social_user(input_user)
+        user: SocialUserSchema = await self.social_service.create_social_user(
+            input_user
+        )
         return JSONResponse(
             status_code=status.HTTP_201_CREATED, content=jsonable_encoder(user)
         )

--- a/app/controller/Social.py
+++ b/app/controller/Social.py
@@ -10,6 +10,8 @@ from fastapi import HTTPException, status, Response
 from fastapi.responses import JSONResponse
 from fastapi.encoders import jsonable_encoder
 
+from app.schemas.SocialUser import SocialUserCreateSchema, SocialUserSchema
+
 
 class SocialController:
 
@@ -63,4 +65,12 @@ class SocialController:
         list = await self.social_service.get_my_feed(user_id, pagination)
         return JSONResponse(
             status_code=status.HTTP_200_OK, content=jsonable_encoder(list)
+        )
+
+    async def handle_create_social_user(
+        self, input_user: SocialUserCreateSchema
+    ) -> JSONResponse:
+        user: SocialUserSchema = await self.social_service.create_social_user(input_user)
+        return JSONResponse(
+            status_code=status.HTTP_201_CREATED, content=jsonable_encoder(user)
         )

--- a/app/controller/Social.py
+++ b/app/controller/Social.py
@@ -58,9 +58,9 @@ class SocialController:
         )
 
     async def handle_get_my_feed(
-        self, id_user: str, pagination: PostPagination
+        self, user_id: int, pagination: PostPagination
     ) -> JSONResponse:
-        list = await self.social_service.get_my_feed(id_user, pagination)
+        list = await self.social_service.get_my_feed(user_id, pagination)
         return JSONResponse(
             status_code=status.HTTP_200_OK, content=jsonable_encoder(list)
         )

--- a/app/docker/init-mongodb.js
+++ b/app/docker/init-mongodb.js
@@ -1,5 +1,7 @@
 db = db.getSiblingDB('social_service');
+
 db.createCollection('posts');
+db.createCollection('users');
 
 db.posts.insertMany([
   {
@@ -8,12 +10,43 @@ db.posts.insertMany([
     "likes_count" : 0,
     "created_at": "2024-04-08T23:18:38.196248",
     "updated_at": "2024-04-08T23:18:38.196248",
+    "photo_links": []
   },
   {
     "author_user_id": 1,
     "content": "Ya soy influenceeeer",
     "likes_count" : 0,
     "created_at": "2024-04-10T15:11:18.196248",
-    "created_at": "2024-04-10T15:11:18.196248"
+    "updated_at": "2024-04-10T15:11:18.196248",
+    "photo_links": []
   }
-]);
+])
+
+// https://github.com/Hanagotchi/users/blob/master/app/docker/tablas.sql 
+// create the users collection with the same structure as the users table!
+db.users.insertMany([
+  {
+    "_id": 1,
+    "followers": [],
+    "following": [],
+    "tags": []
+  }],
+  {
+    "_id": 2,
+    "followers": [],
+    "following": [],
+    "tags": []
+  },
+  {
+    "_id": 3,
+    "followers": [],
+    "following": [],
+    "tags": []
+  },
+  {
+    "_id": 4,
+    "followers": [],
+    "following": [],
+    "tags": []
+  }
+)

--- a/app/docker/init-mongodb.js
+++ b/app/docker/init-mongodb.js
@@ -2,22 +2,23 @@ db = db.getSiblingDB('social_service');
 
 db.createCollection('posts');
 db.createCollection('users');
-
 db.posts.insertMany([
   {
     "author_user_id": 1,
     "content": "Mi Primera Publicacion :D",
     "likes_count" : 0,
-    "created_at": "2024-04-08T23:18:38.196248",
-    "updated_at": "2024-04-08T23:18:38.196248",
-    "photo_links": []
+    "created_at": ISODate("2024-04-15T05:33:33.127Z"),
+    "updated_at":  ISODate("2024-04-15T05:33:33.127Z"),
+    "tags": [],
+    "photo_links": [],
   },
   {
     "author_user_id": 1,
     "content": "Ya soy influenceeeer",
     "likes_count" : 0,
-    "created_at": "2024-04-10T15:11:18.196248",
-    "updated_at": "2024-04-10T15:11:18.196248",
+    "created_at": ISODate("2024-04-19T02:15:30.217Z"),
+    "updated_at": ISODate("2024-04-19T02:15:30.217Z"),
+    "tags": ["influencers"],
     "photo_links": []
   }
 ])
@@ -30,7 +31,7 @@ db.users.insertMany([
     "followers": [],
     "following": [],
     "tags": []
-  }],
+  },
   {
     "_id": 2,
     "followers": [],
@@ -49,4 +50,4 @@ db.users.insertMany([
     "following": [],
     "tags": []
   }
-)
+])

--- a/app/main.py
+++ b/app/main.py
@@ -1,11 +1,14 @@
+from datetime import datetime
 import logging
-from fastapi import FastAPI, Request, Body
+from fastapi import FastAPI, Query, Request, Body
 from app.controller.Social import SocialController
 from app.service.Social import SocialService
+from typing import Annotated
 
 from app.repository.SocialMongo import SocialMongoDB
 from app.schemas.Post import (
     PostCreateSchema,
+    PostPagination,
     PostPartialUpdateSchema,
 )
 
@@ -67,3 +70,22 @@ async def update_fields_in_post(
 )
 def delete_post(id_post: str):
     return social_controller.handle_delete_post(id_post)
+
+
+@app.get(
+    "/social/feed/{id_user}",
+    tags=["Posts"],
+)
+async def get_my_feed(
+    id_user: str,
+    time_offset: Annotated[datetime | None, Query(default_factory=datetime.today)],
+    page: Annotated[int | None, Query(ge=1)] = 1,
+    per_page: Annotated[int | None, Query(ge=1, le=100)] = 30,
+):
+    print(
+        f"[MY FEED] [TIME_OFFSET: {time_offset}] [PAGE: {page}] [PER_PAGE: {per_page}]"
+    )
+
+    return await social_controller.handle_get_my_feed(
+        id_user, PostPagination(time_offset=time_offset, page=page, per_page=per_page)
+    )

--- a/app/main.py
+++ b/app/main.py
@@ -84,10 +84,6 @@ async def get_my_feed(
     page: Annotated[int | None, Query(ge=1)] = 1,
     per_page: Annotated[int | None, Query(ge=1, le=100)] = 30,
 ):
-    print(f"[MY FEED] [USER_ID: {user_id}]")
-    print(
-        f"[MY FEED] [TIME_OFFSET: {time_offset}] [PAGE: {page}] [PER_PAGE: {per_page}]"
-    )
     return await social_controller.handle_get_my_feed(
         user_id, PostPagination(time_offset=time_offset, page=page, per_page=per_page)
     )

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 import logging
-from fastapi import FastAPI, Query, Request, Body
+from fastapi import Depends, FastAPI, Query, Request, Body
 from app.controller.Social import SocialController
 from app.service.Social import SocialService
 from typing import Annotated
@@ -11,6 +11,7 @@ from app.schemas.Post import (
     PostPagination,
     PostPartialUpdateSchema,
 )
+from app.security.JWTBearer import get_current_user_id
 
 app = FastAPI(
     title="Social API",
@@ -73,19 +74,20 @@ def delete_post(id_post: str):
 
 
 @app.get(
-    "/social/feed/{id_user}",
+    "/social/feed",
     tags=["Posts"],
 )
 async def get_my_feed(
-    id_user: str,
+    user_id: Annotated[int, Depends(get_current_user_id)],
     time_offset: Annotated[datetime | None, Query(default_factory=datetime.today)],
     page: Annotated[int | None, Query(ge=1)] = 1,
     per_page: Annotated[int | None, Query(ge=1, le=100)] = 30,
 ):
+    print(f"[MY FEED] [USER_ID: {user_id}]")
     print(
         f"[MY FEED] [TIME_OFFSET: {time_offset}] [PAGE: {page}] [PER_PAGE: {per_page}]"
     )
 
     return await social_controller.handle_get_my_feed(
-        id_user, PostPagination(time_offset=time_offset, page=page, per_page=per_page)
+        user_id, PostPagination(time_offset=time_offset, page=page, per_page=per_page)
     )

--- a/app/main.py
+++ b/app/main.py
@@ -12,6 +12,7 @@ from app.schemas.Post import (
     PostPartialUpdateSchema,
 )
 from app.security.JWTBearer import get_current_user_id
+from app.schemas.SocialUser import SocialUserCreateSchema
 
 app = FastAPI(
     title="Social API",
@@ -74,8 +75,8 @@ def delete_post(id_post: str):
 
 
 @app.get(
-    "/social/feed",
-    tags=["Posts"],
+    "/social/users/me/feed",
+    tags=["Social User"],
 )
 async def get_my_feed(
     user_id: Annotated[int, Depends(get_current_user_id)],
@@ -87,7 +88,14 @@ async def get_my_feed(
     print(
         f"[MY FEED] [TIME_OFFSET: {time_offset}] [PAGE: {page}] [PER_PAGE: {per_page}]"
     )
-
     return await social_controller.handle_get_my_feed(
         user_id, PostPagination(time_offset=time_offset, page=page, per_page=per_page)
     )
+
+
+@app.post(
+    "/social/users",
+    tags=["Social User"],
+)
+async def create_social_user(item: SocialUserCreateSchema):
+    return await social_controller.handle_create_social_user(item)

--- a/app/models/Post.py
+++ b/app/models/Post.py
@@ -16,6 +16,7 @@ class Post(Base):
     likes_count: int = Field(default=0)
     created_at: Optional[datetime]
     updated_at: Optional[datetime]
+    tags: list[str] = []
     photo_links: list[str] = []
 
     class Config:
@@ -37,5 +38,6 @@ class Post(Base):
             content=pydantic_obj.content,
             created_at=None,
             updated_at=None,
+            tags=pydantic_obj.tags if pydantic_obj.tags else [],
             photo_links=pydantic_obj.photo_links if pydantic_obj.photo_links else [],
         )

--- a/app/models/Post.py
+++ b/app/models/Post.py
@@ -16,7 +16,7 @@ class Post(Base):
     likes_count: int = Field(default=0)
     created_at: Optional[datetime]
     updated_at: Optional[datetime]
-    photo_links: Optional[list[str]] = None
+    photo_links: list[str] = []
 
     class Config:
         allow_population_by_field_name = False

--- a/app/models/SocialUser.py
+++ b/app/models/SocialUser.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+from pydantic import Field
+from app.models.base import Base
+from app.schemas.SocialUser import SocialUserCreateSchema
+
+
+class SocialUser(Base):
+    """
+    This class represents a Social user model in the database.
+    """
+
+    __collectionname__ = "users"
+
+    # id of real user in the microservice!
+    id: int = Field(strict=False, alias="_id")
+    followers: list[int] = []
+    following: list[int] = []
+    tags: list[str] = []
+
+    class Config:
+        allow_population_by_field_name = False
+        arbitrary_types_allowed = True
+
+    def __repr__(self) -> str:
+        return (
+            f"Post(id={self.id!r}, followers={self.followers!r}, "
+            f"following={self.following!r}, tags={self.tags!r}"
+        )
+
+    @classmethod
+    def from_pydantic(cls, pydantic_obj: SocialUserCreateSchema):
+        id = pydantic_obj.id
+        dict = pydantic_obj.model_dump(by_alias=True, exclude=["id"])
+
+        # "_id" is the """PK""" in MongoDB
+        dict["_id"] = id
+        return SocialUser(**dict)

--- a/app/repository/SocialMongo.py
+++ b/app/repository/SocialMongo.py
@@ -95,8 +95,9 @@ class SocialMongoDB(SocialRepository):
         ]
         if filters.tags:
             pipeline.append({"$match": {"tags": filters.tags}})
-        if filters.following:
-            pipeline.append({"$match": {"author_user_id": {"$in": filters.following}}})
+        if filters.users:
+            pipeline.append({"$match": {"author_user_id": {"$in": filters.users}}})
+
         pipeline += [
             {"$sort": {"updated_at": -1}},  # sort by updated_at desc
             {"$skip": (filters.pagination.page - 1) * filters.pagination.per_page},

--- a/app/repository/SocialRepository.py
+++ b/app/repository/SocialRepository.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
-from typing import Optional
+from typing import List, Optional
 from app.models.base import Base
+from app.schemas.Post import PostFilters
 
 
 class SocialRepository(ABC):
@@ -15,6 +16,10 @@ class SocialRepository(ABC):
 
     @abstractmethod
     def get_post(self, id_received: int) -> Base:
+        pass
+
+    @abstractmethod
+    def get_posts_by(self, filters: PostFilters) -> List[Base]:
         pass
 
     @abstractmethod

--- a/app/repository/SocialRepository.py
+++ b/app/repository/SocialRepository.py
@@ -33,3 +33,15 @@ class SocialRepository(ABC):
     @abstractmethod
     def delete_post(self, id_received: str) -> int:
         pass
+
+    @abstractmethod
+    def get_following_of(self, user_id: int) -> List[int]:
+        pass
+
+    @abstractmethod
+    def add_social_user(self, record: Base) -> Optional[int]:
+        pass
+
+    @abstractmethod
+    def get_social_user(self, id_received: int) -> Base:
+        pass

--- a/app/schemas/Post.py
+++ b/app/schemas/Post.py
@@ -1,4 +1,3 @@
-from zoneinfo import ZoneInfo
 from pydantic import BaseModel, Field, AfterValidator, HttpUrl
 from typing import Annotated, Optional
 from app.schemas import User

--- a/app/schemas/Post.py
+++ b/app/schemas/Post.py
@@ -126,5 +126,5 @@ class PostPagination(BaseModel):
 
 class PostFilters(BaseModel):
     pagination: PostPagination
-    following: Optional[list[int]] = None
+    users: Optional[list[int]] = None
     tags: Optional[str] = Field(..., min_length=2, max_length=128)

--- a/app/schemas/Post.py
+++ b/app/schemas/Post.py
@@ -1,7 +1,8 @@
+from zoneinfo import ZoneInfo
 from pydantic import BaseModel, Field, AfterValidator, HttpUrl
 from typing import Annotated, Optional
-from datetime import datetime
 from app.schemas import User
+from datetime import datetime
 
 PhotoUrl = Annotated[HttpUrl, AfterValidator(lambda v: str(v))]
 
@@ -57,6 +58,12 @@ class PostSchema(BaseModel):
                 ],
             }
         }
+        # datetime.now(
+        #                         ZoneInfo("America/Argentina/Buenos_Aires")
+        #                     ).isoformat()[:-6]
+        # json_encoders = {datetime: lambda v: datetime.now(
+        #                         ZoneInfo("America/Argentina/Buenos_Aires")
+        #                     ).isoformat()[:-6]}
 
 
 class PostPartialUpdateSchema(BaseModel):
@@ -77,3 +84,15 @@ class PostPartialUpdateSchema(BaseModel):
                 ],
             }
         }
+
+
+class PostPagination(BaseModel):
+    time_offset: datetime
+    page: int
+    per_page: int
+
+
+class PostFilters(BaseModel):
+    pagination: PostPagination
+    following: Optional[list[int]]
+    tags: Optional[str] = Field(..., min_length=2, max_length=128)

--- a/app/schemas/Post.py
+++ b/app/schemas/Post.py
@@ -5,12 +5,14 @@ from datetime import datetime
 
 PhotoUrl = Annotated[HttpUrl, AfterValidator(lambda v: str(v))]
 
+Tag = Annotated[str, Field(..., min_length=2, max_length=128)]
 
 class PostCreateSchema(BaseModel):
     author_user_id: int = Field(..., example=1)
     content: str = Field(..., max_length=512)
+    tags: Optional[list[Tag]] = None
     photo_links: Optional[list[PhotoUrl]] = None
-
+    
     class Config:
         json_schema_extra = {
             "example": {
@@ -24,6 +26,7 @@ class PostCreateSchema(BaseModel):
                     "https://example.com/photo1.jpg",
                     "https://example.com/photo2.jpg",
                 ],
+                "tags": ["petuñas", "mandarinas"],
             }
         }
 
@@ -35,6 +38,7 @@ class PostBaseModel(BaseModel):
     likes_count: int = Field(default=0)
     created_at: datetime
     updated_at: datetime
+    tags: Optional[list[Tag]] = None
 
 
 class PostSchema(PostBaseModel):
@@ -54,6 +58,7 @@ class PostSchema(PostBaseModel):
                 "likes_count": 0,
                 "created_at": "2021-08-08T20:00:00",
                 "updated_at": "2021-08-08T20:00:00",
+                "tags": ["petuñas", "mandarinas"],
                 "photo_links": [
                     "https://example.com/photo1.jpg",
                     "https://example.com/photo2.jpg",
@@ -85,6 +90,7 @@ class PostInFeedSchema(PostBaseModel):
                 "likes_count": 0,
                 "created_at": "2021-08-08T20:00:00",
                 "updated_at": "2021-08-08T20:00:00",
+                "tags": ["petuñas", "mandarinas"],
                 "main_photo_link": "https://example.com/photo1.jpg",
             }
         }
@@ -100,6 +106,7 @@ class PostInFeedSchema(PostBaseModel):
 
 class PostPartialUpdateSchema(BaseModel):
     content: Optional[str] = Field(None, max_length=512)
+    tags: Optional[list[Tag]] = None
     photo_links: Optional[list[PhotoUrl]] = None
 
     class Config:
@@ -110,6 +117,7 @@ class PostPartialUpdateSchema(BaseModel):
                     "Crece, crece y crece, "
                     "y en verano me da mandarinas."
                 ),
+                "tags": ["petuñas", "mandarinas"],
                 "photo_links": [
                     "https://example.com/photo5520.jpg",
                     "https://example.com/photo123.jpg",

--- a/app/schemas/Post.py
+++ b/app/schemas/Post.py
@@ -1,6 +1,6 @@
 from pydantic import BaseModel, Field, AfterValidator, HttpUrl
 from typing import Annotated, Optional
-from app.schemas import User
+from app.schemas.User import UserReduced
 from datetime import datetime
 
 PhotoUrl = Annotated[HttpUrl, AfterValidator(lambda v: str(v))]
@@ -30,7 +30,7 @@ class PostCreateSchema(BaseModel):
 
 class PostSchema(BaseModel):
     id: str = Field(...)
-    author: User = Field(...)
+    author: UserReduced = Field(...)
     content: str = Field(..., max_length=512)
     likes_count: int = Field(default=0)
     created_at: datetime
@@ -93,5 +93,6 @@ class PostPagination(BaseModel):
 
 class PostFilters(BaseModel):
     pagination: PostPagination
-    following: Optional[list[int]]
-    tags: Optional[str] = Field(..., min_length=2, max_length=128)
+    following: Optional[list[int]] = None
+    tags: Optional[str] = Field(..., min_length=2, max_length=128) 
+

--- a/app/schemas/Post.py
+++ b/app/schemas/Post.py
@@ -7,12 +7,13 @@ PhotoUrl = Annotated[HttpUrl, AfterValidator(lambda v: str(v))]
 
 Tag = Annotated[str, Field(..., min_length=2, max_length=128)]
 
+
 class PostCreateSchema(BaseModel):
     author_user_id: int = Field(..., example=1)
     content: str = Field(..., max_length=512)
     tags: Optional[list[Tag]] = None
     photo_links: Optional[list[PhotoUrl]] = None
-    
+
     class Config:
         json_schema_extra = {
             "example": {

--- a/app/schemas/Post.py
+++ b/app/schemas/Post.py
@@ -1,6 +1,6 @@
 from pydantic import BaseModel, Field, AfterValidator, HttpUrl
 from typing import Annotated, Optional
-from app.schemas.User import UserReduced
+from app.schemas.RealUser import ReducedUser
 from datetime import datetime
 
 PhotoUrl = Annotated[HttpUrl, AfterValidator(lambda v: str(v))]
@@ -30,7 +30,7 @@ class PostCreateSchema(BaseModel):
 
 class PostSchema(BaseModel):
     id: str = Field(...)
-    author: UserReduced = Field(...)
+    author: ReducedUser = Field(...)
     content: str = Field(..., max_length=512)
     likes_count: int = Field(default=0)
     created_at: datetime
@@ -94,5 +94,4 @@ class PostPagination(BaseModel):
 class PostFilters(BaseModel):
     pagination: PostPagination
     following: Optional[list[int]] = None
-    tags: Optional[str] = Field(..., min_length=2, max_length=128) 
-
+    tags: Optional[str] = Field(..., min_length=2, max_length=128)

--- a/app/schemas/Post.py
+++ b/app/schemas/Post.py
@@ -28,13 +28,16 @@ class PostCreateSchema(BaseModel):
         }
 
 
-class PostSchema(BaseModel):
+class PostBaseModel(BaseModel):
     id: str = Field(...)
     author: ReducedUser = Field(...)
     content: str = Field(..., max_length=512)
     likes_count: int = Field(default=0)
     created_at: datetime
     updated_at: datetime
+
+
+class PostSchema(PostBaseModel):
     photo_links: Optional[list[PhotoUrl]] = None
 
     class Config:
@@ -63,6 +66,36 @@ class PostSchema(BaseModel):
         # json_encoders = {datetime: lambda v: datetime.now(
         #                         ZoneInfo("America/Argentina/Buenos_Aires")
         #                     ).isoformat()[:-6]}
+
+
+class PostInFeedSchema(PostBaseModel):
+    main_photo_link: Optional[PhotoUrl] = None
+
+    class Config:
+        arbitrary_types_allowed = True
+        json_schema_extra = {
+            "example": {
+                "id": 1,
+                "author_user_id": 1,
+                "content": (
+                    "Mi buena petuña es hermosa. "
+                    "Crece, crece y crece, "
+                    "y en verano me da mandarinas."
+                ),
+                "likes_count": 0,
+                "created_at": "2021-08-08T20:00:00",
+                "updated_at": "2021-08-08T20:00:00",
+                "main_photo_link": "https://example.com/photo1.jpg",
+            }
+        }
+
+    @classmethod
+    def from_post(cls, post: PostSchema):
+        dict = post.model_dump()
+        dict["main_photo_link"] = (
+            dict["photo_links"][0] if dict["photo_links"] else None
+        )
+        return cls(**dict)
 
 
 class PostPartialUpdateSchema(BaseModel):

--- a/app/schemas/RealUser.py
+++ b/app/schemas/RealUser.py
@@ -1,12 +1,13 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 from typing import Dict, Optional
 from datetime import date
 
 
 class GetUserSchema(BaseModel):
     """
-        Schema used to model the response of the `GET /users/{user_id}`endpoint
+    Schema used to model the response of the `GET /users/{user_id}`endpoint
     """
+
     id: int
     name: Optional[str]
     email: Optional[str]
@@ -18,17 +19,18 @@ class GetUserSchema(BaseModel):
     biography: Optional[str]
 
 
-class UserReduced(BaseModel):
+class ReducedUser(BaseModel):
     """
-        Schema used to display the minimal and necessary information of a user in a post.
+    Schema used to display the minimal and necessary information of a user in a post.
     """
+
     name: Optional[str]
     photo: Optional[str]
     nickname: Optional[str]
 
     @classmethod
     def from_pydantic(cls, pydantic_obj: GetUserSchema):
-        return UserReduced(
+        return ReducedUser(
             id=pydantic_obj.id,
             name=pydantic_obj.name,
             photo=pydantic_obj.photo,

--- a/app/schemas/SocialUser.py
+++ b/app/schemas/SocialUser.py
@@ -1,0 +1,15 @@
+from pydantic import BaseModel, Field
+
+
+class SocialUserCreateSchema(BaseModel):
+    id: int = Field(..., gt=0)
+
+
+class SocialUserSchema(BaseModel):
+    id: int = Field(..., alias="_id")
+    followers: list[int] = []
+    following: list[int] = []
+    tags: list[str] = []
+
+    class Config:
+        arbitrary_types_allowed = True

--- a/app/schemas/User.py
+++ b/app/schemas/User.py
@@ -1,9 +1,12 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from typing import Dict, Optional
 from datetime import date
 
 
 class GetUserSchema(BaseModel):
+    """
+        Schema used to model the response of the `GET /users/{user_id}`endpoint
+    """
     id: int
     name: Optional[str]
     email: Optional[str]
@@ -15,15 +18,17 @@ class GetUserSchema(BaseModel):
     biography: Optional[str]
 
 
-class User(BaseModel):
-    id: int
+class UserReduced(BaseModel):
+    """
+        Schema used to display the minimal and necessary information of a user in a post.
+    """
     name: Optional[str]
     photo: Optional[str]
     nickname: Optional[str]
 
     @classmethod
     def from_pydantic(cls, pydantic_obj: GetUserSchema):
-        return User(
+        return UserReduced(
             id=pydantic_obj.id,
             name=pydantic_obj.name,
             photo=pydantic_obj.photo,

--- a/app/security/JWTBearer.py
+++ b/app/security/JWTBearer.py
@@ -1,0 +1,68 @@
+from typing import Annotated
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from fastapi import Request, Depends, HTTPException, status
+from jose import JWTError, jwt
+from pydantic import BaseModel
+
+SECRET_KEY = "secret"
+ALGORITHM = "HS256"
+TOKEN_FIELD_NAME = "x-access-token"
+
+
+class JWTBearer(HTTPBearer):
+    def __init__(self, auto_error: bool = True):
+        super().__init__(auto_error=auto_error)
+
+    async def __call__(self, request: Request):
+        try:
+            credentials: HTTPAuthorizationCredentials = await super().__call__(request)
+            if credentials.scheme != "Bearer" or not self.verify_jwt(
+                credentials.credentials
+            ):
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail="Invalid authentication scheme or token.",
+                )
+            return credentials.credentials
+
+        except Exception:
+            access_token = request.headers.get(TOKEN_FIELD_NAME)
+            if access_token and self.verify_jwt(access_token):
+                return access_token
+
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid authorization code or token.",
+            )
+
+    def verify_jwt(self, jwtoken: str) -> bool:
+        isTokenValid: bool = False
+
+        try:
+            payload = jwt.decode(jwtoken, SECRET_KEY, algorithms=ALGORITHM)
+        except Exception:
+            payload = None
+        if payload:
+            isTokenValid = True
+        return isTokenValid
+
+
+class TokenData(BaseModel):
+    user_id: int | None = None
+
+
+async def get_current_user_id(token: Annotated[dict, Depends(JWTBearer())]):
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        user_id: int = payload.get("user_id")
+        if user_id is None:
+            raise credentials_exception
+        token_data = TokenData(user_id=user_id)
+    except JWTError:
+        raise credentials_exception
+    return token_data.user_id

--- a/app/service/Social.py
+++ b/app/service/Social.py
@@ -64,8 +64,8 @@ class SocialService:
         except Exception as err:
             raise err
 
-    async def get_my_feed(self, id_user: str, pagination: PostPagination):
-        user: GetUserSchema = await UserService.get_user(id_user)
+    async def get_my_feed(self, user_id: int, pagination: PostPagination):
+        user: GetUserSchema = await UserService.get_user(user_id)
         print(f"[USER]: {user}")
         following = [1, 2, 3, 4, 5]
         tags = "AR"

--- a/app/service/Social.py
+++ b/app/service/Social.py
@@ -5,6 +5,8 @@ from app.repository.SocialRepository import SocialRepository
 from app.service.Users import UserService
 from app.schemas.Post import (
     PostCreateSchema,
+    PostFilters,
+    PostPagination,
     PostSchema,
     PostPartialUpdateSchema,
 )
@@ -61,6 +63,17 @@ class SocialService:
             return row_count
         except Exception as err:
             raise err
+
+    async def get_my_feed(self, id_user: str, pagination: PostPagination):
+        user: GetUserSchema = await UserService.get_user(id_user)
+        print(f"[USER]: {user}")
+        following = [1, 2, 3, 4, 5]
+        tags = "AR"
+        filters = PostFilters(pagination=pagination, following=following, tags=tags)
+        print(f"[FILTERS]: {filters}")
+        posts = self.social_repository.get_posts_by(filters)
+        for post in posts:
+            print(f"[POST]: {post}")
 
 
 def map_author_user_id(user, crated_post):

--- a/app/service/Social.py
+++ b/app/service/Social.py
@@ -74,10 +74,8 @@ class SocialService:
         self, user_id: int, pagination: PostPagination
     ) -> List[PostInFeedSchema]:
         following = self.social_repository.get_following_of(user_id)
-        following.append(user_id) # Add the user itself to the feed!
-        filters = PostFilters(
-            pagination=pagination, users=following, tags=None
-        )
+        following.append(user_id)  # Add the user itself to the feed!
+        filters = PostFilters(pagination=pagination, users=following, tags=None)
         print(f"[FILTERS]: {filters}")
         cursor = self.social_repository.get_posts_by(filters)
         fetched_posts = []

--- a/app/service/Social.py
+++ b/app/service/Social.py
@@ -74,8 +74,9 @@ class SocialService:
         self, user_id: int, pagination: PostPagination
     ) -> List[PostInFeedSchema]:
         following = self.social_repository.get_following_of(user_id)
+        following.append(user_id) # Add the user itself to the feed!
         filters = PostFilters(
-            pagination=pagination, following=following if following else None, tags=None
+            pagination=pagination, users=following, tags=None
         )
         print(f"[FILTERS]: {filters}")
         cursor = self.social_repository.get_posts_by(filters)

--- a/app/service/Users.py
+++ b/app/service/Users.py
@@ -3,7 +3,7 @@ from httpx import AsyncClient, HTTPStatusError, Response, AsyncHTTPTransport
 from os import environ
 from app.exceptions.InternalServerErrorException import InternalServerErrorException
 from app.exceptions.NotFoundException import ItemNotFound
-from app.schemas.User import GetUserSchema
+from app.schemas.RealUser import GetUserSchema
 
 logger = logging.getLogger("users")
 logger.setLevel("DEBUG")

--- a/app/service/Users.py
+++ b/app/service/Users.py
@@ -44,3 +44,18 @@ class UserService:
         except Exception as e:
             print(f"Unexpected error: {e}")
             raise InternalServerErrorException("User service")
+
+    @staticmethod
+    async def user_exists(user_id: int) -> bool:
+        try:
+            response = await UserService.get(f"/users/{user_id}")
+            return response.status_code == 200
+        except HTTPStatusError as e:
+            if e.response.status_code == 404:
+                return False
+            else:
+                print(f"HTTPStatusError error: {e}")
+                raise InternalServerErrorException("User service")
+        except Exception as e:
+            print(f"Unexpected error: {e}")
+            raise InternalServerErrorException("User service")

--- a/app/service/Users.py
+++ b/app/service/Users.py
@@ -46,6 +46,21 @@ class UserService:
             raise InternalServerErrorException("User service")
 
     @staticmethod
+    async def get_users(users_ids_to_fetch: list) -> list:
+        try:
+            response = await UserService.get(
+                f"/users?ids={','.join(map(str, users_ids_to_fetch))}"
+            )
+            if response.status_code == 200:
+                users = response.json()["message"]
+                return [GetUserSchema(**user) for user in users]
+            else:
+                raise InternalServerErrorException("User service")
+        except Exception as e:
+            print(f"Unexpected error: {e}")
+            raise InternalServerErrorException("User service")
+
+    @staticmethod
     async def user_exists(user_id: int) -> bool:
         try:
             response = await UserService.get(f"/users/{user_id}")

--- a/app/utils/mongo_exception_handling.py
+++ b/app/utils/mongo_exception_handling.py
@@ -2,7 +2,7 @@ import logging
 from app.exceptions.BadRequestException import BadRequestException
 from bson.errors import BSONError, InvalidId
 from pymongo.errors import PyMongoError
-from app.exceptions import InternalServerErrorException
+from app.exceptions.InternalServerErrorException import InternalServerErrorException
 
 logger = logging.getLogger("app")
 logger.setLevel("DEBUG")

--- a/app/utils/update_at_trigger.py
+++ b/app/utils/update_at_trigger.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 from functools import wraps
 import logging
-from zoneinfo import ZoneInfo
 from bson import ObjectId
 
 logger = logging.getLogger("app")
@@ -31,13 +30,7 @@ def updatedAtTrigger(collection_name: str):
                 )
                 collection.update_one(
                     {"_id": ObjectId(id_post)},
-                    {
-                        "$set": {
-                            "updated_at": datetime.now(
-                                ZoneInfo("America/Argentina/Buenos_Aires")
-                            ).isoformat()[:-6]
-                        }
-                    },
+                    {"$set": {"updated_at": datetime.now()}},
                 )
 
             return result

--- a/poetry.lock
+++ b/poetry.lock
@@ -333,6 +333,23 @@ files = [
 ]
 
 [[package]]
+name = "pyjwt"
+version = "2.8.0"
+description = "JSON Web Token implementation in Python"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "PyJWT-2.8.0-py3-none-any.whl", hash = "sha256:59127c392cc44c2da5bb3192169a91f429924e17aff6534d70fdc02ab3e04320"},
+    {file = "PyJWT-2.8.0.tar.gz", hash = "sha256:57e28d156e3d5c10088e0c68abb90bfac3df82b40a71bd0daa20c65ccd5c23de"},
+]
+
+[package.extras]
+crypto = ["cryptography (>=3.4.0)"]
+dev = ["coverage[toml] (==5.0.4)", "cryptography (>=3.4.0)", "pre-commit", "pytest (>=6.0.0,<7.0.0)", "sphinx (>=4.5.0,<5.0.0)", "sphinx-rtd-theme", "zope.interface"]
+docs = ["sphinx (>=4.5.0,<5.0.0)", "sphinx-rtd-theme", "zope.interface"]
+tests = ["coverage[toml] (==5.0.4)", "pytest (>=6.0.0,<7.0.0)"]
+
+[[package]]
 name = "pymongo"
 version = "4.6.3"
 description = "Python driver for MongoDB <http://www.mongodb.org>"
@@ -509,4 +526,4 @@ standard = ["colorama (>=0.4)", "httptools (>=0.5.0)", "python-dotenv (>=0.13)",
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "7979dade728c62c2095bcc13f0ee5fea4d609ddce69ffd711b9cc6b3acb23dd4"
+content-hash = "dd19926a3e0b1561fbb48365013edec0a47a7ee7bf84af05bf028c82ad57c25c"

--- a/poetry.lock
+++ b/poetry.lock
@@ -88,6 +88,24 @@ trio = ["trio (>=0.23)"]
 wmi = ["wmi (>=1.5.1)"]
 
 [[package]]
+name = "ecdsa"
+version = "0.19.0"
+description = "ECDSA cryptographic signature library (pure python)"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.6"
+files = [
+    {file = "ecdsa-0.19.0-py2.py3-none-any.whl", hash = "sha256:2cea9b88407fdac7bbeca0833b189e4c9c53f2ef1e1eaa29f6224dbc809b707a"},
+    {file = "ecdsa-0.19.0.tar.gz", hash = "sha256:60eaad1199659900dd0af521ed462b793bbdf867432b3948e87416ae4caf6bf8"},
+]
+
+[package.dependencies]
+six = ">=1.9.0"
+
+[package.extras]
+gmpy = ["gmpy"]
+gmpy2 = ["gmpy2"]
+
+[[package]]
 name = "fastapi"
 version = "0.109.2"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
@@ -180,13 +198,13 @@ socks = ["socksio (==1.*)"]
 
 [[package]]
 name = "idna"
-version = "3.6"
+version = "3.7"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
 python-versions = ">=3.5"
 files = [
-    {file = "idna-3.6-py3-none-any.whl", hash = "sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f"},
-    {file = "idna-3.6.tar.gz", hash = "sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca"},
+    {file = "idna-3.7-py3-none-any.whl", hash = "sha256:82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0"},
+    {file = "idna-3.7.tar.gz", hash = "sha256:028ff3aadf0609c1fd278d8ea3089299412a7a8b9bd005dd08b9f8285bcb5cfc"},
 ]
 
 [[package]]
@@ -198,6 +216,17 @@ python-versions = ">=3.6"
 files = [
     {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
     {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.0"
+description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pyasn1-0.6.0-py2.py3-none-any.whl", hash = "sha256:cca4bb0f2df5504f02f6f8a775b6e416ff9b0b3b16f7ee80b5a3153d9b804473"},
+    {file = "pyasn1-0.6.0.tar.gz", hash = "sha256:3a35ab2c4b5ef98e17dfdec8ab074046fbda76e281c5a706ccd82328cfc8f64c"},
 ]
 
 [[package]]
@@ -213,18 +242,18 @@ files = [
 
 [[package]]
 name = "pydantic"
-version = "2.6.4"
+version = "2.7.0"
 description = "Data validation using Python type hints"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pydantic-2.6.4-py3-none-any.whl", hash = "sha256:cc46fce86607580867bdc3361ad462bab9c222ef042d3da86f2fb333e1d916c5"},
-    {file = "pydantic-2.6.4.tar.gz", hash = "sha256:b1704e0847db01817624a6b86766967f552dd9dbf3afba4004409f908dcc84e6"},
+    {file = "pydantic-2.7.0-py3-none-any.whl", hash = "sha256:9dee74a271705f14f9a1567671d144a851c675b072736f0a7b2608fd9e495352"},
+    {file = "pydantic-2.7.0.tar.gz", hash = "sha256:b5ecdd42262ca2462e2624793551e80911a1e989f462910bb81aef974b4bb383"},
 ]
 
 [package.dependencies]
 annotated-types = ">=0.4.0"
-pydantic-core = "2.16.3"
+pydantic-core = "2.18.1"
 typing-extensions = ">=4.6.1"
 
 [package.extras]
@@ -232,90 +261,90 @@ email = ["email-validator (>=2.0.0)"]
 
 [[package]]
 name = "pydantic-core"
-version = "2.16.3"
-description = ""
+version = "2.18.1"
+description = "Core functionality for Pydantic validation and serialization"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pydantic_core-2.16.3-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:75b81e678d1c1ede0785c7f46690621e4c6e63ccd9192af1f0bd9d504bbb6bf4"},
-    {file = "pydantic_core-2.16.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9c865a7ee6f93783bd5d781af5a4c43dadc37053a5b42f7d18dc019f8c9d2bd1"},
-    {file = "pydantic_core-2.16.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:162e498303d2b1c036b957a1278fa0899d02b2842f1ff901b6395104c5554a45"},
-    {file = "pydantic_core-2.16.3-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2f583bd01bbfbff4eaee0868e6fc607efdfcc2b03c1c766b06a707abbc856187"},
-    {file = "pydantic_core-2.16.3-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b926dd38db1519ed3043a4de50214e0d600d404099c3392f098a7f9d75029ff8"},
-    {file = "pydantic_core-2.16.3-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:716b542728d4c742353448765aa7cdaa519a7b82f9564130e2b3f6766018c9ec"},
-    {file = "pydantic_core-2.16.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fc4ad7f7ee1a13d9cb49d8198cd7d7e3aa93e425f371a68235f784e99741561f"},
-    {file = "pydantic_core-2.16.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:bd87f48924f360e5d1c5f770d6155ce0e7d83f7b4e10c2f9ec001c73cf475c99"},
-    {file = "pydantic_core-2.16.3-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:0df446663464884297c793874573549229f9eca73b59360878f382a0fc085979"},
-    {file = "pydantic_core-2.16.3-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:4df8a199d9f6afc5ae9a65f8f95ee52cae389a8c6b20163762bde0426275b7db"},
-    {file = "pydantic_core-2.16.3-cp310-none-win32.whl", hash = "sha256:456855f57b413f077dff513a5a28ed838dbbb15082ba00f80750377eed23d132"},
-    {file = "pydantic_core-2.16.3-cp310-none-win_amd64.whl", hash = "sha256:732da3243e1b8d3eab8c6ae23ae6a58548849d2e4a4e03a1924c8ddf71a387cb"},
-    {file = "pydantic_core-2.16.3-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:519ae0312616026bf4cedc0fe459e982734f3ca82ee8c7246c19b650b60a5ee4"},
-    {file = "pydantic_core-2.16.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b3992a322a5617ded0a9f23fd06dbc1e4bd7cf39bc4ccf344b10f80af58beacd"},
-    {file = "pydantic_core-2.16.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8d62da299c6ecb04df729e4b5c52dc0d53f4f8430b4492b93aa8de1f541c4aac"},
-    {file = "pydantic_core-2.16.3-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2acca2be4bb2f2147ada8cac612f8a98fc09f41c89f87add7256ad27332c2fda"},
-    {file = "pydantic_core-2.16.3-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1b662180108c55dfbf1280d865b2d116633d436cfc0bba82323554873967b340"},
-    {file = "pydantic_core-2.16.3-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e7c6ed0dc9d8e65f24f5824291550139fe6f37fac03788d4580da0d33bc00c97"},
-    {file = "pydantic_core-2.16.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a6b1bb0827f56654b4437955555dc3aeeebeddc47c2d7ed575477f082622c49e"},
-    {file = "pydantic_core-2.16.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e56f8186d6210ac7ece503193ec84104da7ceb98f68ce18c07282fcc2452e76f"},
-    {file = "pydantic_core-2.16.3-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:936e5db01dd49476fa8f4383c259b8b1303d5dd5fb34c97de194560698cc2c5e"},
-    {file = "pydantic_core-2.16.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:33809aebac276089b78db106ee692bdc9044710e26f24a9a2eaa35a0f9fa70ba"},
-    {file = "pydantic_core-2.16.3-cp311-none-win32.whl", hash = "sha256:ded1c35f15c9dea16ead9bffcde9bb5c7c031bff076355dc58dcb1cb436c4721"},
-    {file = "pydantic_core-2.16.3-cp311-none-win_amd64.whl", hash = "sha256:d89ca19cdd0dd5f31606a9329e309d4fcbb3df860960acec32630297d61820df"},
-    {file = "pydantic_core-2.16.3-cp311-none-win_arm64.whl", hash = "sha256:6162f8d2dc27ba21027f261e4fa26f8bcb3cf9784b7f9499466a311ac284b5b9"},
-    {file = "pydantic_core-2.16.3-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:0f56ae86b60ea987ae8bcd6654a887238fd53d1384f9b222ac457070b7ac4cff"},
-    {file = "pydantic_core-2.16.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c9bd22a2a639e26171068f8ebb5400ce2c1bc7d17959f60a3b753ae13c632975"},
-    {file = "pydantic_core-2.16.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4204e773b4b408062960e65468d5346bdfe139247ee5f1ca2a378983e11388a2"},
-    {file = "pydantic_core-2.16.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f651dd19363c632f4abe3480a7c87a9773be27cfe1341aef06e8759599454120"},
-    {file = "pydantic_core-2.16.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:aaf09e615a0bf98d406657e0008e4a8701b11481840be7d31755dc9f97c44053"},
-    {file = "pydantic_core-2.16.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8e47755d8152c1ab5b55928ab422a76e2e7b22b5ed8e90a7d584268dd49e9c6b"},
-    {file = "pydantic_core-2.16.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:500960cb3a0543a724a81ba859da816e8cf01b0e6aaeedf2c3775d12ee49cade"},
-    {file = "pydantic_core-2.16.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:cf6204fe865da605285c34cf1172879d0314ff267b1c35ff59de7154f35fdc2e"},
-    {file = "pydantic_core-2.16.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:d33dd21f572545649f90c38c227cc8631268ba25c460b5569abebdd0ec5974ca"},
-    {file = "pydantic_core-2.16.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:49d5d58abd4b83fb8ce763be7794d09b2f50f10aa65c0f0c1696c677edeb7cbf"},
-    {file = "pydantic_core-2.16.3-cp312-none-win32.whl", hash = "sha256:f53aace168a2a10582e570b7736cc5bef12cae9cf21775e3eafac597e8551fbe"},
-    {file = "pydantic_core-2.16.3-cp312-none-win_amd64.whl", hash = "sha256:0d32576b1de5a30d9a97f300cc6a3f4694c428d956adbc7e6e2f9cad279e45ed"},
-    {file = "pydantic_core-2.16.3-cp312-none-win_arm64.whl", hash = "sha256:ec08be75bb268473677edb83ba71e7e74b43c008e4a7b1907c6d57e940bf34b6"},
-    {file = "pydantic_core-2.16.3-cp38-cp38-macosx_10_12_x86_64.whl", hash = "sha256:b1f6f5938d63c6139860f044e2538baeee6f0b251a1816e7adb6cbce106a1f01"},
-    {file = "pydantic_core-2.16.3-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:2a1ef6a36fdbf71538142ed604ad19b82f67b05749512e47f247a6ddd06afdc7"},
-    {file = "pydantic_core-2.16.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:704d35ecc7e9c31d48926150afada60401c55efa3b46cd1ded5a01bdffaf1d48"},
-    {file = "pydantic_core-2.16.3-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d937653a696465677ed583124b94a4b2d79f5e30b2c46115a68e482c6a591c8a"},
-    {file = "pydantic_core-2.16.3-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c9803edf8e29bd825f43481f19c37f50d2b01899448273b3a7758441b512acf8"},
-    {file = "pydantic_core-2.16.3-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:72282ad4892a9fb2da25defeac8c2e84352c108705c972db82ab121d15f14e6d"},
-    {file = "pydantic_core-2.16.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7f752826b5b8361193df55afcdf8ca6a57d0232653494ba473630a83ba50d8c9"},
-    {file = "pydantic_core-2.16.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4384a8f68ddb31a0b0c3deae88765f5868a1b9148939c3f4121233314ad5532c"},
-    {file = "pydantic_core-2.16.3-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:a4b2bf78342c40b3dc830880106f54328928ff03e357935ad26c7128bbd66ce8"},
-    {file = "pydantic_core-2.16.3-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:13dcc4802961b5f843a9385fc821a0b0135e8c07fc3d9949fd49627c1a5e6ae5"},
-    {file = "pydantic_core-2.16.3-cp38-none-win32.whl", hash = "sha256:e3e70c94a0c3841e6aa831edab1619ad5c511199be94d0c11ba75fe06efe107a"},
-    {file = "pydantic_core-2.16.3-cp38-none-win_amd64.whl", hash = "sha256:ecdf6bf5f578615f2e985a5e1f6572e23aa632c4bd1dc67f8f406d445ac115ed"},
-    {file = "pydantic_core-2.16.3-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:bda1ee3e08252b8d41fa5537413ffdddd58fa73107171a126d3b9ff001b9b820"},
-    {file = "pydantic_core-2.16.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:21b888c973e4f26b7a96491c0965a8a312e13be108022ee510248fe379a5fa23"},
-    {file = "pydantic_core-2.16.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:be0ec334369316fa73448cc8c982c01e5d2a81c95969d58b8f6e272884df0074"},
-    {file = "pydantic_core-2.16.3-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b5b6079cc452a7c53dd378c6f881ac528246b3ac9aae0f8eef98498a75657805"},
-    {file = "pydantic_core-2.16.3-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7ee8d5f878dccb6d499ba4d30d757111847b6849ae07acdd1205fffa1fc1253c"},
-    {file = "pydantic_core-2.16.3-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7233d65d9d651242a68801159763d09e9ec96e8a158dbf118dc090cd77a104c9"},
-    {file = "pydantic_core-2.16.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c6119dc90483a5cb50a1306adb8d52c66e447da88ea44f323e0ae1a5fcb14256"},
-    {file = "pydantic_core-2.16.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:578114bc803a4c1ff9946d977c221e4376620a46cf78da267d946397dc9514a8"},
-    {file = "pydantic_core-2.16.3-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:d8f99b147ff3fcf6b3cc60cb0c39ea443884d5559a30b1481e92495f2310ff2b"},
-    {file = "pydantic_core-2.16.3-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:4ac6b4ce1e7283d715c4b729d8f9dab9627586dafce81d9eaa009dd7f25dd972"},
-    {file = "pydantic_core-2.16.3-cp39-none-win32.whl", hash = "sha256:e7774b570e61cb998490c5235740d475413a1f6de823169b4cf94e2fe9e9f6b2"},
-    {file = "pydantic_core-2.16.3-cp39-none-win_amd64.whl", hash = "sha256:9091632a25b8b87b9a605ec0e61f241c456e9248bfdcf7abdf344fdb169c81cf"},
-    {file = "pydantic_core-2.16.3-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:36fa178aacbc277bc6b62a2c3da95226520da4f4e9e206fdf076484363895d2c"},
-    {file = "pydantic_core-2.16.3-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:dcca5d2bf65c6fb591fff92da03f94cd4f315972f97c21975398bd4bd046854a"},
-    {file = "pydantic_core-2.16.3-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2a72fb9963cba4cd5793854fd12f4cfee731e86df140f59ff52a49b3552db241"},
-    {file = "pydantic_core-2.16.3-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b60cc1a081f80a2105a59385b92d82278b15d80ebb3adb200542ae165cd7d183"},
-    {file = "pydantic_core-2.16.3-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:cbcc558401de90a746d02ef330c528f2e668c83350f045833543cd57ecead1ad"},
-    {file = "pydantic_core-2.16.3-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:fee427241c2d9fb7192b658190f9f5fd6dfe41e02f3c1489d2ec1e6a5ab1e04a"},
-    {file = "pydantic_core-2.16.3-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:f4cb85f693044e0f71f394ff76c98ddc1bc0953e48c061725e540396d5c8a2e1"},
-    {file = "pydantic_core-2.16.3-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:b29eeb887aa931c2fcef5aa515d9d176d25006794610c264ddc114c053bf96fe"},
-    {file = "pydantic_core-2.16.3-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:a425479ee40ff021f8216c9d07a6a3b54b31c8267c6e17aa88b70d7ebd0e5e5b"},
-    {file = "pydantic_core-2.16.3-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:5c5cbc703168d1b7a838668998308018a2718c2130595e8e190220238addc96f"},
-    {file = "pydantic_core-2.16.3-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:99b6add4c0b39a513d323d3b93bc173dac663c27b99860dd5bf491b240d26137"},
-    {file = "pydantic_core-2.16.3-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:75f76ee558751746d6a38f89d60b6228fa174e5172d143886af0f85aa306fd89"},
-    {file = "pydantic_core-2.16.3-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:00ee1c97b5364b84cb0bd82e9bbf645d5e2871fb8c58059d158412fee2d33d8a"},
-    {file = "pydantic_core-2.16.3-pp39-pypy39_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:287073c66748f624be4cef893ef9174e3eb88fe0b8a78dc22e88eca4bc357ca6"},
-    {file = "pydantic_core-2.16.3-pp39-pypy39_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:ed25e1835c00a332cb10c683cd39da96a719ab1dfc08427d476bce41b92531fc"},
-    {file = "pydantic_core-2.16.3-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:86b3d0033580bd6bbe07590152007275bd7af95f98eaa5bd36f3da219dcd93da"},
-    {file = "pydantic_core-2.16.3.tar.gz", hash = "sha256:1cac689f80a3abab2d3c0048b29eea5751114054f032a941a32de4c852c59cad"},
+    {file = "pydantic_core-2.18.1-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:ee9cf33e7fe14243f5ca6977658eb7d1042caaa66847daacbd2117adb258b226"},
+    {file = "pydantic_core-2.18.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:6b7bbb97d82659ac8b37450c60ff2e9f97e4eb0f8a8a3645a5568b9334b08b50"},
+    {file = "pydantic_core-2.18.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:df4249b579e75094f7e9bb4bd28231acf55e308bf686b952f43100a5a0be394c"},
+    {file = "pydantic_core-2.18.1-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d0491006a6ad20507aec2be72e7831a42efc93193d2402018007ff827dc62926"},
+    {file = "pydantic_core-2.18.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2ae80f72bb7a3e397ab37b53a2b49c62cc5496412e71bc4f1277620a7ce3f52b"},
+    {file = "pydantic_core-2.18.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:58aca931bef83217fca7a390e0486ae327c4af9c3e941adb75f8772f8eeb03a1"},
+    {file = "pydantic_core-2.18.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1be91ad664fc9245404a789d60cba1e91c26b1454ba136d2a1bf0c2ac0c0505a"},
+    {file = "pydantic_core-2.18.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:667880321e916a8920ef49f5d50e7983792cf59f3b6079f3c9dac2b88a311d17"},
+    {file = "pydantic_core-2.18.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:f7054fdc556f5421f01e39cbb767d5ec5c1139ea98c3e5b350e02e62201740c7"},
+    {file = "pydantic_core-2.18.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:030e4f9516f9947f38179249778709a460a3adb516bf39b5eb9066fcfe43d0e6"},
+    {file = "pydantic_core-2.18.1-cp310-none-win32.whl", hash = "sha256:2e91711e36e229978d92642bfc3546333a9127ecebb3f2761372e096395fc649"},
+    {file = "pydantic_core-2.18.1-cp310-none-win_amd64.whl", hash = "sha256:9a29726f91c6cb390b3c2338f0df5cd3e216ad7a938762d11c994bb37552edb0"},
+    {file = "pydantic_core-2.18.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:9ece8a49696669d483d206b4474c367852c44815fca23ac4e48b72b339807f80"},
+    {file = "pydantic_core-2.18.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7a5d83efc109ceddb99abd2c1316298ced2adb4570410defe766851a804fcd5b"},
+    {file = "pydantic_core-2.18.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5f7973c381283783cd1043a8c8f61ea5ce7a3a58b0369f0ee0ee975eaf2f2a1b"},
+    {file = "pydantic_core-2.18.1-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:54c7375c62190a7845091f521add19b0f026bcf6ae674bdb89f296972272e86d"},
+    {file = "pydantic_core-2.18.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dd63cec4e26e790b70544ae5cc48d11b515b09e05fdd5eff12e3195f54b8a586"},
+    {file = "pydantic_core-2.18.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:561cf62c8a3498406495cfc49eee086ed2bb186d08bcc65812b75fda42c38294"},
+    {file = "pydantic_core-2.18.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:68717c38a68e37af87c4da20e08f3e27d7e4212e99e96c3d875fbf3f4812abfc"},
+    {file = "pydantic_core-2.18.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2d5728e93d28a3c63ee513d9ffbac9c5989de8c76e049dbcb5bfe4b923a9739d"},
+    {file = "pydantic_core-2.18.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:f0f17814c505f07806e22b28856c59ac80cee7dd0fbb152aed273e116378f519"},
+    {file = "pydantic_core-2.18.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:d816f44a51ba5175394bc6c7879ca0bd2be560b2c9e9f3411ef3a4cbe644c2e9"},
+    {file = "pydantic_core-2.18.1-cp311-none-win32.whl", hash = "sha256:09f03dfc0ef8c22622eaa8608caa4a1e189cfb83ce847045eca34f690895eccb"},
+    {file = "pydantic_core-2.18.1-cp311-none-win_amd64.whl", hash = "sha256:27f1009dc292f3b7ca77feb3571c537276b9aad5dd4efb471ac88a8bd09024e9"},
+    {file = "pydantic_core-2.18.1-cp311-none-win_arm64.whl", hash = "sha256:48dd883db92e92519201f2b01cafa881e5f7125666141a49ffba8b9facc072b0"},
+    {file = "pydantic_core-2.18.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:b6b0e4912030c6f28bcb72b9ebe4989d6dc2eebcd2a9cdc35fefc38052dd4fe8"},
+    {file = "pydantic_core-2.18.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f3202a429fe825b699c57892d4371c74cc3456d8d71b7f35d6028c96dfecad31"},
+    {file = "pydantic_core-2.18.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a3982b0a32d0a88b3907e4b0dc36809fda477f0757c59a505d4e9b455f384b8b"},
+    {file = "pydantic_core-2.18.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:25595ac311f20e5324d1941909b0d12933f1fd2171075fcff763e90f43e92a0d"},
+    {file = "pydantic_core-2.18.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:14fe73881cf8e4cbdaded8ca0aa671635b597e42447fec7060d0868b52d074e6"},
+    {file = "pydantic_core-2.18.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ca976884ce34070799e4dfc6fbd68cb1d181db1eefe4a3a94798ddfb34b8867f"},
+    {file = "pydantic_core-2.18.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:684d840d2c9ec5de9cb397fcb3f36d5ebb6fa0d94734f9886032dd796c1ead06"},
+    {file = "pydantic_core-2.18.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:54764c083bbe0264f0f746cefcded6cb08fbbaaf1ad1d78fb8a4c30cff999a90"},
+    {file = "pydantic_core-2.18.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:201713f2f462e5c015b343e86e68bd8a530a4f76609b33d8f0ec65d2b921712a"},
+    {file = "pydantic_core-2.18.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fd1a9edb9dd9d79fbeac1ea1f9a8dd527a6113b18d2e9bcc0d541d308dae639b"},
+    {file = "pydantic_core-2.18.1-cp312-none-win32.whl", hash = "sha256:d5e6b7155b8197b329dc787356cfd2684c9d6a6b1a197f6bbf45f5555a98d411"},
+    {file = "pydantic_core-2.18.1-cp312-none-win_amd64.whl", hash = "sha256:9376d83d686ec62e8b19c0ac3bf8d28d8a5981d0df290196fb6ef24d8a26f0d6"},
+    {file = "pydantic_core-2.18.1-cp312-none-win_arm64.whl", hash = "sha256:c562b49c96906b4029b5685075fe1ebd3b5cc2601dfa0b9e16c2c09d6cbce048"},
+    {file = "pydantic_core-2.18.1-cp38-cp38-macosx_10_12_x86_64.whl", hash = "sha256:3e352f0191d99fe617371096845070dee295444979efb8f27ad941227de6ad09"},
+    {file = "pydantic_core-2.18.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:c0295d52b012cbe0d3059b1dba99159c3be55e632aae1999ab74ae2bd86a33d7"},
+    {file = "pydantic_core-2.18.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:56823a92075780582d1ffd4489a2e61d56fd3ebb4b40b713d63f96dd92d28144"},
+    {file = "pydantic_core-2.18.1-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:dd3f79e17b56741b5177bcc36307750d50ea0698df6aa82f69c7db32d968c1c2"},
+    {file = "pydantic_core-2.18.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:38a5024de321d672a132b1834a66eeb7931959c59964b777e8f32dbe9523f6b1"},
+    {file = "pydantic_core-2.18.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d2ce426ee691319d4767748c8e0895cfc56593d725594e415f274059bcf3cb76"},
+    {file = "pydantic_core-2.18.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2adaeea59849ec0939af5c5d476935f2bab4b7f0335b0110f0f069a41024278e"},
+    {file = "pydantic_core-2.18.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9b6431559676a1079eac0f52d6d0721fb8e3c5ba43c37bc537c8c83724031feb"},
+    {file = "pydantic_core-2.18.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:85233abb44bc18d16e72dc05bf13848a36f363f83757541f1a97db2f8d58cfd9"},
+    {file = "pydantic_core-2.18.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:641a018af4fe48be57a2b3d7a1f0f5dbca07c1d00951d3d7463f0ac9dac66622"},
+    {file = "pydantic_core-2.18.1-cp38-none-win32.whl", hash = "sha256:63d7523cd95d2fde0d28dc42968ac731b5bb1e516cc56b93a50ab293f4daeaad"},
+    {file = "pydantic_core-2.18.1-cp38-none-win_amd64.whl", hash = "sha256:907a4d7720abfcb1c81619863efd47c8a85d26a257a2dbebdb87c3b847df0278"},
+    {file = "pydantic_core-2.18.1-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:aad17e462f42ddbef5984d70c40bfc4146c322a2da79715932cd8976317054de"},
+    {file = "pydantic_core-2.18.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:94b9769ba435b598b547c762184bcfc4783d0d4c7771b04a3b45775c3589ca44"},
+    {file = "pydantic_core-2.18.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:80e0e57cc704a52fb1b48f16d5b2c8818da087dbee6f98d9bf19546930dc64b5"},
+    {file = "pydantic_core-2.18.1-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:76b86e24039c35280ceee6dce7e62945eb93a5175d43689ba98360ab31eebc4a"},
+    {file = "pydantic_core-2.18.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:12a05db5013ec0ca4a32cc6433f53faa2a014ec364031408540ba858c2172bb0"},
+    {file = "pydantic_core-2.18.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:250ae39445cb5475e483a36b1061af1bc233de3e9ad0f4f76a71b66231b07f88"},
+    {file = "pydantic_core-2.18.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a32204489259786a923e02990249c65b0f17235073149d0033efcebe80095570"},
+    {file = "pydantic_core-2.18.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6395a4435fa26519fd96fdccb77e9d00ddae9dd6c742309bd0b5610609ad7fb2"},
+    {file = "pydantic_core-2.18.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:2533ad2883f001efa72f3d0e733fb846710c3af6dcdd544fe5bf14fa5fe2d7db"},
+    {file = "pydantic_core-2.18.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:b560b72ed4816aee52783c66854d96157fd8175631f01ef58e894cc57c84f0f6"},
+    {file = "pydantic_core-2.18.1-cp39-none-win32.whl", hash = "sha256:582cf2cead97c9e382a7f4d3b744cf0ef1a6e815e44d3aa81af3ad98762f5a9b"},
+    {file = "pydantic_core-2.18.1-cp39-none-win_amd64.whl", hash = "sha256:ca71d501629d1fa50ea7fa3b08ba884fe10cefc559f5c6c8dfe9036c16e8ae89"},
+    {file = "pydantic_core-2.18.1-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:e178e5b66a06ec5bf51668ec0d4ac8cfb2bdcb553b2c207d58148340efd00143"},
+    {file = "pydantic_core-2.18.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:72722ce529a76a4637a60be18bd789d8fb871e84472490ed7ddff62d5fed620d"},
+    {file = "pydantic_core-2.18.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2fe0c1ce5b129455e43f941f7a46f61f3d3861e571f2905d55cdbb8b5c6f5e2c"},
+    {file = "pydantic_core-2.18.1-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d4284c621f06a72ce2cb55f74ea3150113d926a6eb78ab38340c08f770eb9b4d"},
+    {file = "pydantic_core-2.18.1-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a0c3e718f4e064efde68092d9d974e39572c14e56726ecfaeebbe6544521f47"},
+    {file = "pydantic_core-2.18.1-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:2027493cc44c23b598cfaf200936110433d9caa84e2c6cf487a83999638a96ac"},
+    {file = "pydantic_core-2.18.1-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:76909849d1a6bffa5a07742294f3fa1d357dc917cb1fe7b470afbc3a7579d539"},
+    {file = "pydantic_core-2.18.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:ee7ccc7fb7e921d767f853b47814c3048c7de536663e82fbc37f5eb0d532224b"},
+    {file = "pydantic_core-2.18.1-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:ee2794111c188548a4547eccc73a6a8527fe2af6cf25e1a4ebda2fd01cdd2e60"},
+    {file = "pydantic_core-2.18.1-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:a139fe9f298dc097349fb4f28c8b81cc7a202dbfba66af0e14be5cfca4ef7ce5"},
+    {file = "pydantic_core-2.18.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d074b07a10c391fc5bbdcb37b2f16f20fcd9e51e10d01652ab298c0d07908ee2"},
+    {file = "pydantic_core-2.18.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c69567ddbac186e8c0aadc1f324a60a564cfe25e43ef2ce81bcc4b8c3abffbae"},
+    {file = "pydantic_core-2.18.1-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:baf1c7b78cddb5af00971ad5294a4583188bda1495b13760d9f03c9483bb6203"},
+    {file = "pydantic_core-2.18.1-pp39-pypy39_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:2684a94fdfd1b146ff10689c6e4e815f6a01141781c493b97342cdc5b06f4d5d"},
+    {file = "pydantic_core-2.18.1-pp39-pypy39_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:73c1bc8a86a5c9e8721a088df234265317692d0b5cd9e86e975ce3bc3db62a59"},
+    {file = "pydantic_core-2.18.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:e60defc3c15defb70bb38dd605ff7e0fae5f6c9c7cbfe0ad7868582cb7e844a6"},
+    {file = "pydantic_core-2.18.1.tar.gz", hash = "sha256:de9d3e8717560eb05e28739d1b35e4eac2e458553a52a301e51352a7ffc86a35"},
 ]
 
 [package.dependencies]
@@ -331,23 +360,6 @@ files = [
     {file = "pyflakes-3.2.0-py2.py3-none-any.whl", hash = "sha256:84b5be138a2dfbb40689ca07e2152deb896a65c3a3e24c251c5c62489568074a"},
     {file = "pyflakes-3.2.0.tar.gz", hash = "sha256:1c61603ff154621fb2a9172037d84dca3500def8c8b630657d1701f026f8af3f"},
 ]
-
-[[package]]
-name = "pyjwt"
-version = "2.8.0"
-description = "JSON Web Token implementation in Python"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "PyJWT-2.8.0-py3-none-any.whl", hash = "sha256:59127c392cc44c2da5bb3192169a91f429924e17aff6534d70fdc02ab3e04320"},
-    {file = "PyJWT-2.8.0.tar.gz", hash = "sha256:57e28d156e3d5c10088e0c68abb90bfac3df82b40a71bd0daa20c65ccd5c23de"},
-]
-
-[package.extras]
-crypto = ["cryptography (>=3.4.0)"]
-dev = ["coverage[toml] (==5.0.4)", "cryptography (>=3.4.0)", "pre-commit", "pytest (>=6.0.0,<7.0.0)", "sphinx (>=4.5.0,<5.0.0)", "sphinx-rtd-theme", "zope.interface"]
-docs = ["sphinx (>=4.5.0,<5.0.0)", "sphinx-rtd-theme", "zope.interface"]
-tests = ["coverage[toml] (==5.0.4)", "pytest (>=6.0.0,<7.0.0)"]
 
 [[package]]
 name = "pymongo"
@@ -467,6 +479,52 @@ files = [
 cli = ["click (>=5.0)"]
 
 [[package]]
+name = "python-jose"
+version = "3.3.0"
+description = "JOSE implementation in Python"
+optional = false
+python-versions = "*"
+files = [
+    {file = "python-jose-3.3.0.tar.gz", hash = "sha256:55779b5e6ad599c6336191246e95eb2293a9ddebd555f796a65f838f07e5d78a"},
+    {file = "python_jose-3.3.0-py2.py3-none-any.whl", hash = "sha256:9b1376b023f8b298536eedd47ae1089bcdb848f1535ab30555cd92002d78923a"},
+]
+
+[package.dependencies]
+ecdsa = "!=0.15"
+pyasn1 = "*"
+rsa = "*"
+
+[package.extras]
+cryptography = ["cryptography (>=3.4.0)"]
+pycrypto = ["pyasn1", "pycrypto (>=2.6.0,<2.7.0)"]
+pycryptodome = ["pyasn1", "pycryptodome (>=3.3.1,<4.0.0)"]
+
+[[package]]
+name = "rsa"
+version = "4.9"
+description = "Pure-Python RSA implementation"
+optional = false
+python-versions = ">=3.6,<4"
+files = [
+    {file = "rsa-4.9-py3-none-any.whl", hash = "sha256:90260d9058e514786967344d0ef75fa8727eed8a7d2e43ce9f4bcf1b536174f7"},
+    {file = "rsa-4.9.tar.gz", hash = "sha256:e38464a49c6c85d7f1351b0126661487a7e0a14a50f1675ec50eb34d4f20ef21"},
+]
+
+[package.dependencies]
+pyasn1 = ">=0.1.3"
+
+[[package]]
+name = "six"
+version = "1.16.0"
+description = "Python 2 and 3 compatibility utilities"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+files = [
+    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
+    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 description = "Sniff out which async library your code is running under"
@@ -526,4 +584,4 @@ standard = ["colorama (>=0.4)", "httptools (>=0.5.0)", "python-dotenv (>=0.13)",
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "dd19926a3e0b1561fbb48365013edec0a47a7ee7bf84af05bf028c82ad57c25c"
+content-hash = "0628b5175b3ee7ab7b40ef7e27efb8e17836b22d1b35ba6dabe1f1fbb9c66329"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ python-dotenv = "^1.0.1"
 flake8 = "^7.0.0"
 httpx = "^0.26.0"
 pymongo = "^4.6.3"
-pyjwt = "^2.8.0"
+python-jose = "^3.3.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ python-dotenv = "^1.0.1"
 flake8 = "^7.0.0"
 httpx = "^0.26.0"
 pymongo = "^4.6.3"
+pyjwt = "^2.8.0"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
## Linked ticket in Jira
- https://hanagotchi.atlassian.net/browse/HAN-91

## Describe your changes, marking the new features and possible risks

- Se agrega endpoint `POST /social/users` crea un usuario como entidad en MongoDB, pero el microservicio de red social ahora guarda el contenido mínimo `{followers, following, tags}` de los usuarios para ser utilizada el servicio.
  - Su identificador "_id" en MongoDB es el ID de los usuarios del microservicio de usuarios (no es un ObjectID autogenerado).
- Se agrega endpoint de `GET /social/users/me/feed` para obtener mi feed como usuario logueado.
  - Se agrega capa de seguridad `JWTBearer` para gestionar el token JWT que se recibe por los headers.
  - El feed consiste en ver las publicaciones de mis usuarios seguidos y mi propio feed. Si no sigo a nadie solo veré mis propias publicaciones.
  - Se resuelve con un filtro genérico en la capa de repositorio mediante la función `get_posts_by()` y esquema `PostFilters`.
- De yapa se agrega modelos con tags en los esquemas. Idem con los seguidores y seguidos. Pero falta implementar sus endpoints...
- Tuve que borrar los posteos de mongoDB deployado, peldón. Problemas con el datetime...

## Media: upload photos or videos (if needed)

![image](https://github.com/Hanagotchi/social/assets/51347305/12cd3e28-c6f6-4cca-8f7b-01d573eb7779)

Se puede probar endpoint de GET pasandole el access token desde el swagger. Debe ser valido emitido por el microservicio de usuarios.
