### PR TITLE
Remove warnings

### DIFF
--- a/app/controller/Social.py
+++ b/app/controller/Social.py
@@ -160,10 +160,7 @@ class SocialController:
     ) -> JSONResponse:
         result = await self.social_service.like_post(user_id, post_id)
         if result is None or result == 0:
-            return JSONResponse(
-                status_code=status.HTTP_204_NO_CONTENT,
-                content=""
-            )
+            return Response(status_code=status.HTTP_204_NO_CONTENT)
 
         return JSONResponse(
             status_code=status.HTTP_200_OK,
@@ -178,10 +175,7 @@ class SocialController:
         result = await self.social_service.unlike_post(user_id, post_id)
 
         if result is None or result == 0:
-            return JSONResponse(
-                status_code=status.HTTP_204_NO_CONTENT,
-                content=""
-            )
+            return Response(status_code=status.HTTP_204_NO_CONTENT)
 
         return JSONResponse(
             status_code=status.HTTP_200_OK,
@@ -228,7 +222,7 @@ class SocialController:
                 content=jsonable_encoder(followers)
             )
         return JSONResponse(
-            status_code=status.HTTP_204_NO_CONTENT,
+            status_code=status.HTTP_200_OK,
             content=jsonable_encoder(followers)
         )
 
@@ -240,6 +234,6 @@ class SocialController:
                 content=jsonable_encoder(users)
             )
         return JSONResponse(
-            status_code=status.HTTP_204_NO_CONTENT,
+            status_code=status.HTTP_200_OK,
             content=jsonable_encoder(users)
         )

--- a/app/models/Post.py
+++ b/app/models/Post.py
@@ -23,7 +23,7 @@ class Post(Base):
     comments_count: int = Field(default=0)
 
     class Config:
-        allow_population_by_field_name = False
+        populate_by_name = False
         arbitrary_types_allowed = True
         json_encoders = {ObjectId: str}
 

--- a/app/models/SocialUser.py
+++ b/app/models/SocialUser.py
@@ -18,7 +18,7 @@ class SocialUser(Base):
     tags: list[str] = []
 
     class Config:
-        allow_population_by_field_name = False
+        populate_by_name = False
         arbitrary_types_allowed = True
 
     def __repr__(self) -> str:

--- a/app/schemas/Post.py
+++ b/app/schemas/Post.py
@@ -33,7 +33,7 @@ class PostCreateSchema(BaseModel):
     comments: list[PostCommentSchema] = []
 
     class Config:
-        json_schema_extra = {
+        json_json_schema_extra = {
             "example": {
                 "author_user_id": 17,
                 "content": (
@@ -71,7 +71,7 @@ class PostSchema(PostBaseModel):
 
     class Config:
         arbitrary_types_allowed = True
-        json_schema_extra = {
+        json_json_schema_extra = {
             "example": {
                 "id": 1,
                 "author": 17,
@@ -104,7 +104,7 @@ class PostInFeedSchema(PostBaseModel):
 
     class Config:
         arbitrary_types_allowed = True
-        json_schema_extra = {
+        json_json_schema_extra = {
             "example": {
                 "id": 1,
                 "author_user_id": 17,
@@ -140,7 +140,7 @@ class PostPartialUpdateSchema(BaseModel):
     comments_count: Optional[int] = None
 
     class Config:
-        json_schema_extra = {
+        json_json_schema_extra = {
             "example": {
                 "content": (
                     "Mi buena petuña es hermosa. "

--- a/app/schemas/Post.py
+++ b/app/schemas/Post.py
@@ -33,7 +33,7 @@ class PostCreateSchema(BaseModel):
     comments: list[PostCommentSchema] = []
 
     class Config:
-        json_json_schema_extra = {
+        json_schema_extra = {
             "example": {
                 "author_user_id": 17,
                 "content": (
@@ -71,7 +71,7 @@ class PostSchema(PostBaseModel):
 
     class Config:
         arbitrary_types_allowed = True
-        json_json_schema_extra = {
+        json_schema_extra = {
             "example": {
                 "id": 1,
                 "author": 17,
@@ -104,7 +104,7 @@ class PostInFeedSchema(PostBaseModel):
 
     class Config:
         arbitrary_types_allowed = True
-        json_json_schema_extra = {
+        json_schema_extra = {
             "example": {
                 "id": 1,
                 "author_user_id": 17,
@@ -140,7 +140,7 @@ class PostPartialUpdateSchema(BaseModel):
     comments_count: Optional[int] = None
 
     class Config:
-        json_json_schema_extra = {
+        json_schema_extra = {
             "example": {
                 "content": (
                     "Mi buena petuña es hermosa. "


### PR DESCRIPTION
- renombré variable que ha sido deprecada: en los logs lo tiraba como warning
- cambié responses de los 204 ya que al retornar "{}" o "" el JSONReponse asignaba un body y violaba el content length igual a 0 que debe retornar los 204: en los logs lo tiraba como warning
- cambio un HTTP_204_NO_CONTENT que debía ser HTTP_200_OK

